### PR TITLE
Update Startup.cs

### DIFF
--- a/src/DotNurse.Injector/Startup.cs
+++ b/src/DotNurse.Injector/Startup.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace DotNurse.Injector
 {
     public static class Startup
     {

--- a/src/DotNurse.Injector/Startup.cs
+++ b/src/DotNurse.Injector/Startup.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Extensions.Hosting;
 
 namespace DotNurse.Injector
 {


### PR DESCRIPTION
Changed Namespace in Startup.

This is to fix an issue where the UseDotNurseInjector extension method was not showing up.

When I copied this class to a file in my project, and changed the namespace as above, then it successfully showed up as an extension method.

See [this](https://stackoverflow.com/questions/2525205/why-is-my-extension-method-not-showing-up-in-my-test-classl) about not using framework class namespaces.

Also note that I am using this in a aspnetcore 5 project.