### PR TITLE
Non-Public injecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,15 @@ You must replace your Service Provider with .Nurse Injecor to use **Attribute In
 
 ### Usage
 ```csharp
-[InjectService] public IBookRepository BookRepository { get; set; }
+[InjectService] public IBookRepository BookRepository { get; private set; }
 ```
 
 ```csharp
-[InjectService] public IBookRepository bookRepository;
+[InjectService] protected IBookRepository bookRepository;
 ```
 
+### Known Issues with DotNurse Container
+- #8
 
 ***
 

--- a/sandbox/MultiLayeredService/Controllers/BooksController.cs
+++ b/sandbox/MultiLayeredService/Controllers/BooksController.cs
@@ -14,19 +14,19 @@ namespace MultiLayeredService.Controllers
     [Route("api/[controller]")]
     public class BooksController : ControllerBase
     {
-        [InjectService] public IBookRepository bookRepository;
+        [InjectService] private IBookRepository bookRepository;
         [InjectService] public IBookRepository BookRepository { get; set; }
 
         [HttpGet]
         public IActionResult Get()
         {
-            return Ok(BookRepository.Get());
+            return Ok(bookRepository.Get());
         }
 
         [HttpGet("{id}")]
         public IActionResult Get(string id)
         {
-            return Ok(BookRepository.GetSingle(id));
+            return Ok(bookRepository.GetSingle(id));
         }
     }
 }

--- a/sandbox/MultiLayeredService/Controllers/BooksController.cs
+++ b/sandbox/MultiLayeredService/Controllers/BooksController.cs
@@ -15,12 +15,12 @@ namespace MultiLayeredService.Controllers
     public class BooksController : ControllerBase
     {
         [InjectService] private IBookRepository bookRepository;
-        [InjectService] public IBookRepository BookRepository { get; set; }
+        [InjectService] public IBookRepository BookRepository { get; protected set; }
 
         [HttpGet]
         public IActionResult Get()
         {
-            return Ok(bookRepository.Get());
+            return Ok(BookRepository.Get());
         }
 
         [HttpGet("{id}")]

--- a/src/DotNurse.Injector/DotNurseAttributeInjector.cs
+++ b/src/DotNurse.Injector/DotNurseAttributeInjector.cs
@@ -12,7 +12,7 @@ public class DotNurseAttributeInjector : IAttributeInjector
 {
     public void InjectIntoMembers(object instance, IServiceProvider serviceProvider)
     {
-        var members = instance.GetType().GetMembers().Where(x => x.IsDefined(typeof(InjectServiceAttribute)));
+        var members = instance.GetType().GetMembers(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public).Where(x => x.IsDefined(typeof(InjectServiceAttribute)));
         foreach (var member in members)
         {
             if (member is PropertyInfo propertyInfo)


### PR DESCRIPTION
DotNurse Container will be able to inject into non-public properties and fields. But notice that, a property to be injected by attribute must have a setter even it's private or protected.